### PR TITLE
Add enhancer argument to createStore function in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Program:
 [<EntryPoint>]
 let main argv =
 
-    let store = createStore incrementDecrementReducer { CurrentValue = 0 }
+    let store = createStore incrementDecrementReducer { CurrentValue = 0 } id
     let unsubscribe = store.Subscribe(consoleLogSubscriber)
 
     store.Dispatch (Increment { Amount = 1 }) |> ignore


### PR DESCRIPTION
`README` example misses the enhancer argument, so I cannot run it successfully. Added `id` function to leave the store as is.